### PR TITLE
Revert XML namespace name to `android`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:_="http://schemas.android.com/apk/res/android" package="au.com.msbit.gradle_android_minimal">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="au.com.msbit.gradle_android_minimal">
   <application>
-    <activity _:name=".MainActivity">
+    <activity android:name=".MainActivity">
       <intent-filter>
-        <action _:name="android.intent.action.MAIN"/>
-        <category _:name="android.intent.category.LAUNCHER"/>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
   </application>


### PR DESCRIPTION
It seems like some of the AndroidX dependencies tweak the
`AndroidManifest.xml` file in a really simplistic way (ie, not
aware of the fully qualified names in XML), so they _need_ the
namespace to be called `android`. Le sigh.